### PR TITLE
Add option if to use collection/publication/subscription

### DIFF
--- a/seo.coffee
+++ b/seo.coffee
@@ -24,12 +24,13 @@
   deps: []
 
   config: (settings) ->
+    self = @
     _.extend(@settings, settings)
 
     if @settings.use_collection is true
       # Get seo settings depending on route
       @deps.push Deps.autorun( ->
-        currentRouteName = getCurrentRouteName()
+        currentRouteName = self.getCurrentRouteName()
         return unless currentRouteName
         Meteor.subscribe('seoByRouteName', currentRouteName)
       )
@@ -37,7 +38,7 @@
       # Set seo settings depending on route
       @deps.push Deps.autorun( ->
         return unless SEO
-        currentRouteName = getCurrentRouteName()
+        currentRouteName = self.getCurrentRouteName()
         settings = SeoCollection.findOne({route_name: currentRouteName}) or {}
         SEO.set(settings)
       )
@@ -157,7 +158,7 @@
       return
 
     return unless content
-    content = escapeHtmlAttribute(content)
+    content = @escapeHtmlAttribute(content)
 
     $('head').append("<meta #{attr} content='#{content}'>")
 


### PR DESCRIPTION
- added option if to use collection as route settings source, publication, and subscription (default to false -- must be)
- move some methods under SEO instance `(getCurrentRouteName, escapeHtmlAttribute)``
- it automatically creates Deps.autoruns if config is executed with settings of `use_collection: true`

I would gladly appreciate if you look into this. Thanks man!
