### PR TITLE
Facebook meta properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ You can set some standard values. This will be set if nothing else is available.
             },
             og: {
               'image': 'http://manuel-schoebel.com/images/authors/manuel-schoebel.jpg' 
+            },
+            fb: {
+              'app_id': '1234567890'
             }
           });
         }
@@ -99,6 +102,9 @@ Often times you want to set your SEO data dynamically, for example if you have a
             og: {
               'title': post.title,
               'description': post.description
+            },
+            fb: {
+              'app_id': '1234567890'
             }
           });
         }

--- a/seo.coffee
+++ b/seo.coffee
@@ -4,6 +4,7 @@ SEO =
     rel_author: ''
     meta: []
     og: []
+    fb: []
     twitter: []
     ignore:
       meta: ['fragment']
@@ -30,6 +31,7 @@ SEO =
 
     meta = options.meta
     og = options.og
+    fb = options.fb
     link = options.link
     twitter = options.twitter
 
@@ -55,6 +57,14 @@ SEO =
     else if og and _.isObject(og)
       for k, v of og
         @setMeta("property='og:#{k}'", v)
+
+    # set fb
+    if fb and _.isArray(fb)
+      for f in fb
+        @setMeta("property='fb:#{f.key}'", f.value)
+    else if fb and _.isObject(fb)
+      for k, v of fb
+        @setMeta("property='fb:#{k}'", v)
 
     # set link
     # as array {href: "...", rel: "..."}


### PR DESCRIPTION
Facebook needs meta property `fb:app_id` or `fb:admins` to get [website insights](https://developers.facebook.com/docs/platforminsights/domains). These changes support adding `fb:...` properties.
