### PR TITLE
Workaround: router.route('/') makes this nag user

### DIFF
--- a/seo.coffee
+++ b/seo.coffee
@@ -158,6 +158,8 @@ getCurrentRouteName = ->
   router = Router.current()
   return unless router
   routeName = router.route.getName()
+  if not routeName and router.route.path() is '/'
+    routeName = '/'
   return routeName
 
 # Get seo settings depending on route


### PR DESCRIPTION
The auto-route-namer doesn't work for the route for '/' - this is because it likes the route names to be accessible via dot syntax. Anyway, this causes getCurrentRouteName to incorrectly cause '/' routes to nag the user á la https://github.com/DerMambo/ms-seo/issues/43. This should fix that nagging. I did write this patch in Github so please please test that this works before merge :)

Cheers,
Carl
